### PR TITLE
Added windows support

### DIFF
--- a/Lib/StringExtensions.cs
+++ b/Lib/StringExtensions.cs
@@ -6,14 +6,14 @@ namespace AdventOfCode {
     public static class StringExtensions {
         public static string StripMargin(this string st, string margin = "|") {
             return string.Join("\n",
-                from line in st.Split('\n')
+                from line in Regex.Split(st, "\r?\n")
                 select Regex.Replace(line, @"^\s*"+Regex.Escape(margin), "")
             );
         }
 
         public static string Indent(this string st, int l) {
             return string.Join("\n" + new string(' ', l),
-                from line in st.Split('\n')
+                from line in Regex.Split(st, "\r?\n")
                 select Regex.Replace(line, @"^\s*\|", "")
             );
         }


### PR DESCRIPTION
In SplashScreen.cs, on windows, instead of 
```csharp
            Write(0xffff66, false, "\n /\\   _|     _  ._ _|_    _ _|_   /   _   _|  _  \n/--\\ (_| \\/ (/_ | | |_   (_) |    \\_ (_) (_| (/_ ");
            Write(0xffff66, false, " 2020\n\n                            ");
```

I have
```csharp
            Write(0xffff66, false, "
\n /\\   _|     _  ._ _|_    _ _|_   /   _   _|  _  
\n/--\\ (_| \\/ (/_ | | |_   (_) |    \\_ (_) (_| (/");
            Write(0xffff66, false, "_  2020
\n\n                            ");
```

So I changed `String.Split` method to `Regex.Split` to support windows NewLine